### PR TITLE
Wrong action_size and observation shape in Torch Wrapper

### DIFF
--- a/cherry/envs/torch_wrapper.py
+++ b/cherry/envs/torch_wrapper.py
@@ -29,7 +29,7 @@ class Torch(Wrapper):
             state = {k: self._convert_state(state[k]) for k in state}
         if isinstance(state, np.ndarray):
             state = ch.totensor(state)
-        if self.is_vectorized and isinstance(state, th.Tensor):
+        if isinstance(state, th.Tensor):
             state = state.squeeze(0)
         return state
 

--- a/cherry/envs/utils.py
+++ b/cherry/envs/utils.py
@@ -75,9 +75,4 @@ def get_space_dimension(space, vectorized=False):
         }
         return OrderedDict(dimensions)
     if isinstance(space, Tuple):
-        if not vectorized:
-            return get_space_dimension(space[0], vectorized)
-        dimensions = tuple(
-            get_space_dimension(s) for s in space
-        )
-        return dimensions
+        return get_space_dimension(space[0])

--- a/tests/unit/vec_env_tests.py
+++ b/tests/unit/vec_env_tests.py
@@ -1,0 +1,25 @@
+import unittest
+import gym
+import cherry
+
+class VecEnvTests(unittest.TestCase):
+    def test_vecenv(self):
+        gym_env = gym.vector.make('CartPole-v0', num_envs=2)
+        cherry_env = cherry.envs.Torch(gym_env)
+        
+        assert cherry_env.action_size == gym_env.action_space[0].n
+        assert cherry_env.state_size == gym_env.observation_space.shape[1]
+        
+        assert gym_env.reset().shape == cherry_env.reset().shape
+
+
+        gym_env = gym.vector.make('CartPole-v0', num_envs=3)
+        cherry_env = cherry.envs.Torch(gym_env)
+        
+        assert cherry_env.action_size == gym_env.action_space[0].n
+        assert cherry_env.state_size == gym_env.observation_space.shape[1]
+        
+        assert gym_env.reset().shape == cherry_env.reset().shape
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
First of all nice job with cherry, I am using it for some experiments and I am loving it!

When I try to run this code:
```
gym_env = gym.vector.make('CartPole-v0', num_envs=1)
cherry_env = cherry.envs.Torch(gym_env)

print("Gym spaces: ", gym_env.action_space, gym_env.observation_space)
print("Gym observation: ", gym_env.reset().shape)
print("Cherry spaces: ", cherry_env.action_size, cherry_env.state_size)
print("Cherry observation: ", cherry_env.reset().shape)
```

I get

```
Gym spaces:  Tuple(Discrete(2)) Box(1, 4)
Gym observation:  (1, 4)
Cherry spaces:  (2,) 4
Cherry observation:  torch.Size([1, 1, 4])
```

And with `num_envs=2` I get:

```
Gym spaces:  Tuple(Discrete(2), Discrete(2)) Box(2, 4)
Gym observation:  (2, 4)
Cherry spaces:  2 4
Cherry observation:  torch.Size([2, 4])
```

If i got the semantic of `action_size` and `state_size` right I should have got the same values (`2 4`) for the two execution.
In order to fix this i just removed the `vectorized` check in `get_space_dimension` in `cherry/envs/utils.py`.

Furthermore the cherry observation should be the same of the gym observation in the first case (with `Box(1, 4)` it should be `torch.Size([1, 4])` and a fix for this is just skipping the `vectorized` check in `_convert_state` of `Torch(Wrapper)`.

Running the same code with `num_envs=1` with those fixes i get

```
Gym spaces:  Tuple(Discrete(2)) Box(1, 4)
Gym observation:  (1, 4)
Cherry spaces:  2 4
Cherry observation:  torch.Size([1, 4])
```

And with `num_envs=2` i get

```
Gym spaces:  Tuple(Discrete(2), Discrete(2)) Box(2, 4)
Gym observation:  (2, 4)
Cherry spaces:  2 4
Cherry observation:  torch.Size([2, 4])
```

I also wrote a very simple unit test for this.

 This fix seems to brake the `integration.actor_critic_tests.TestActorCritic` so maybe I am missing something.

Without the fix the A2C example is broken:
```
Traceback (most recent call last):
  File "examples/actor_critic_cartpole.py", line 91, in <module>
    policy = ActorCriticNet(env)
  File "examples/actor_critic_cartpole.py", line 39, in __init__
    self.action_head = nn.Linear(128, env.action_size)
  File "/home/federico/Documents/GitHub/cherry/env/lib/python3.6/site-packages/torch-1.4.0-py3.6-linux-x86_64.egg/torch/nn/modules/linear.py", line 72, in __init__
    self.weight = Parameter(torch.Tensor(out_features, in_features))
TypeError: new() received an invalid combination of arguments - got (tuple, int), but expected one of:
 * (torch.device device)
 * (torch.Storage storage)
 * (Tensor other)
 * (tuple of ints size, torch.device device)
      didn't match because some of the arguments have invalid types: (tuple, int)
 * (object data, torch.device device)
      didn't match because some of the arguments have invalid types: (tuple, int)
```

with the fix is still broken but in a different way:
```
Traceback (most recent call last):
  File "examples/actor_critic_cartpole.py", line 98, in <module>
    replay = env.run(get_action, episodes=1)
  File "/home/federico/Documents/GitHub/cherry/env/lib/python3.6/site-packages/cherry_rl-0.1.2-py3.6.egg/cherry/envs/runner_wrapper.py", line 139, in run
  File "/home/federico/Documents/GitHub/cherry/env/lib/python3.6/site-packages/cherry_rl-0.1.2-py3.6.egg/cherry/envs/torch_wrapper.py", line 58, in step
  File "/home/federico/Documents/GitHub/cherry/env/lib/python3.6/site-packages/cherry_rl-0.1.2-py3.6.egg/cherry/envs/logger_wrapper.py", line 145, in step
  File "/home/federico/Documents/GitHub/cherry/env/lib/python3.6/site-packages/gym-0.16.0-py3.6.egg/gym/vector/vector_env.py", line 91, in step
    self.step_async(actions)
  File "/home/federico/Documents/GitHub/cherry/env/lib/python3.6/site-packages/gym-0.16.0-py3.6.egg/gym/vector/async_vector_env.py", line 196, in step_async
    for pipe, action in zip(self.parent_pipes, actions):
TypeError: zip argument #2 must support iteration
```

This seems to have something to do with the `Logger` wrapper. I do not have time to check it right now but if you want i can check it tomorrow.