### PR TITLE
New A2C example with entropy

### DIFF
--- a/examples/actor_critic_cartpole.py
+++ b/examples/actor_critic_cartpole.py
@@ -1,112 +1,122 @@
 #!/usr/bin/env python3
 
-"""
-Simple example of using cherry to solve cartpole with an actor-critic.
-
-The code is an adaptation of the PyTorch reinforcement learning example.
-"""
-
-import random
+import torch
+import cherry
 import gym
 import numpy as np
-
 from itertools import count
 
-import torch as th
-import torch.nn as nn
-import torch.nn.functional as F
-import torch.optim as optim
+SEED = 42
 
-import cherry.envs as envs
-from cherry.td import discount
-from cherry import normalize
-import cherry.distributions as distributions
+class A2C(torch.nn.Module):
+    def __init__(self):
+        super(A2C, self).__init__()
+        
+        self.gamma = 0.99
+        self.vf_coef = 0.5
+        self.ent_coef = 0.01
 
-SEED = 567
-GAMMA = 0.99
-RENDER = False
-V_WEIGHT = 0.5
+    def select_action(self, state):
+        probs, value = self(state)
+        mass = torch.distributions.Categorical(probs)
+        action = mass.sample()
+        # Return selected action, logprob, value estimation and categorical entropy
+        return action, {"log_prob": mass.log_prob(action), "value": value, "entropy": mass.entropy()}
 
-random.seed(SEED)
-np.random.seed(SEED)
-th.manual_seed(SEED)
+    
+    def learn_step(self, replay, optimizer):
+        policy_loss = []
+        value_loss = []
+        entropy_loss = []
+
+        # Discount and normalize rewards
+        rewards = cherry.td.discount(self.gamma, replay.reward(), replay.done())
+        rewards = cherry.normalize(rewards)
+
+        # Value function error (MSE)
+        value_loss_fn = torch.nn.MSELoss()
+        for sars, reward in zip(replay, rewards):
+            log_prob = sars.log_prob
+            value = sars.value
+            entropy = sars.entropy
+
+            # Compute advantage
+            advantage = reward - value.squeeze(0)
+            
+            # Compute policy gradient loss
+            # (advantage.detach() because you do not have to backward on the advantage path) 
+            policy_loss.append(-log_prob * advantage.detach())
+            # Compute value estimation loss
+            value_loss.append(value_loss_fn(value.squeeze(0), reward))
+            # Compute entropy loss
+            entropy_loss.append(entropy)
+        
+        # Compute means over the accumulated errors
+        policy_loss = torch.stack(policy_loss).mean()
+        value_loss = torch.stack(value_loss).mean()
+        entropy_loss = torch.stack(entropy_loss).mean()
+
+        # Take an optimization step
+        optimizer.zero_grad()
+        loss = policy_loss + self.vf_coef * value_loss - self.ent_coef * entropy_loss
+        loss.backward()
+        optimizer.step()
 
 
-class ActorCriticNet(nn.Module):
-    def __init__(self, env):
-        super(ActorCriticNet, self).__init__()
-        self.affine1 = nn.Linear(env.state_size, 128)
-        self.action_head = nn.Linear(128, env.action_size)
-        self.value_head = nn.Linear(128, 1)
-        self.distribution = distributions.ActionDistribution(env,
-                                                             use_probs=True)
+
+class A2CPolicy(A2C):
+    def __init__(self, state_size, action_size):
+        super(A2CPolicy, self).__init__()
+        self.state_size = state_size
+        self.action_size = action_size
+        self.n_hidden = 128
+
+        # Backbone net
+        self.net = torch.nn.Sequential(
+            torch.nn.Linear(self.state_size, self.n_hidden),
+            torch.nn.LeakyReLU(),
+            torch.nn.Linear(self.n_hidden, self.n_hidden),
+            torch.nn.LeakyReLU(),
+        )
+
+        # Action head (policy gradient)
+        self.action_head = torch.nn.Sequential(
+            torch.nn.Linear(self.n_hidden, self.action_size),
+            torch.nn.Softmax(dim=1)
+        )
+
+        # Value estimation head (A2C)
+        self.value_head = torch.nn.Sequential(
+            torch.nn.Linear(self.n_hidden, 1),
+        )
+
 
     def forward(self, x):
-        x = F.relu(self.affine1(x))
-        action_scores = self.action_head(x)
-        action_mass = self.distribution(F.softmax(action_scores, dim=1))
-        value = self.value_head(x)
-        return action_mass, value
-
-
-def update(replay, optimizer):
-    policy_loss = []
-    value_loss = []
-
-    # Discount and normalize rewards
-    rewards = discount(GAMMA, replay.reward(), replay.done())
-    rewards = normalize(rewards)
-
-    # Compute losses
-    for sars, reward in zip(replay, rewards):
-        log_prob = sars.log_prob
-        value = sars.value
-        policy_loss.append(-log_prob * (reward - value.item()))
-        value_loss.append(F.mse_loss(value, reward.detach()))
-
-    # Take optimization step
-    optimizer.zero_grad()
-    loss = th.stack(policy_loss).sum() + V_WEIGHT * th.stack(value_loss).sum()
-    loss.backward()
-    optimizer.step()
-
-
-def get_action_value(state, policy):
-    mass, value = policy(state)
-    action = mass.sample()
-    info = {
-        'log_prob': mass.log_prob(action),  # Cache log_prob for later
-        'value': value
-    }
-    return action, info
-
+        # Return both the action probabilities and the value estimations
+        return self.action_head(self.net(x)), self.value_head(self.net(x))
 
 if __name__ == '__main__':
-    env = gym.vector.make('CartPole-v0', num_envs=1)
-    env = envs.Logger(env, interval=1000)
-    env = envs.Torch(env)
-    env = envs.Runner(env)
+    env = gym.make('CartPole-v0')
+    env = cherry.envs.Logger(env, interval=1000)
+    env = cherry.envs.Torch(env)
+    env = cherry.envs.Runner(env)
     env.seed(SEED)
 
-    policy = ActorCriticNet(env)
-    optimizer = optim.Adam(policy.parameters(), lr=1e-2)
-    running_reward = 10.0
-    get_action = lambda state: get_action_value(state, policy)
+    policy = A2CPolicy(env.state_size, env.action_size)
+    optimizer = torch.optim.Adam(policy.parameters(), lr=1e-3)
 
+    running_reward = 10
     for episode in count(1):
-        # We use the Runner collector, but could've written our own
-        replay = env.run(get_action, episodes=1)
+        replay = env.run(lambda state: policy.select_action(state), episodes=1)
+        policy.learn_step(replay, optimizer)
 
-        # Update policy
-        update(replay, optimizer)
-
-        # Compute termination criterion
-        running_reward = running_reward * 0.99 + len(replay) * 0.01
-        if episode % 10 == 0:
-            # Should start with 10.41, 12.21, 14.60, then 100:71.30, 200:135.74
-            print(episode, running_reward)
+        running_reward = running_reward * 0.99 + replay.reward().sum() * 0.01
+        
         if running_reward > 190.0:
             print('Solved! Running reward now {} and '
                   'the last episode runs to {} time steps!'.format(running_reward,
                                                                    len(replay)))
             break
+    
+    while True:
+        env.run(lambda state: policy.select_action(state), episodes=1, render=True)


### PR DESCRIPTION
Hi it is me again :sweat_smile:
Since I'm working with cherry these days I thought of sharing my implementation of A2C as the new `actor_critic_cartpole.py` example.
My implementation is the same as the baselines one with the entropy loss and using the mean as reduction instead of the sum. It is divided in two classes (one for the A2C logic and one child class for the actual policy). I have also used only the declarative interface of pytorch (just becouse i like it more than the functional :smiley:)
I think that a different coding style with respect to the policy gradient example might be useful to have in the examples folder.
I have tested it and it should be safe to merge, but of course more benchmarking is still required (that is never enough :smiley:) 