### PR TITLE
Vec discount fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,5 +18,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* Bugfix when using `td.discount` with replays coming from vectorized environments (@galatolofederico) 
 * Actor-critic integration test being to finicky.
 * `cherry.onehot` support for numpy's float and integer types. (thanks @ngoby)

--- a/cherry/td.py
+++ b/cherry/td.py
@@ -52,7 +52,7 @@ def discount(gamma, rewards, dones, bootstrap=0.0):
 
     msg = 'dones and rewards must have equal length.'
     assert rewards.size(0) == dones.size(0), msg
-    R = th.zeros_like(rewards[0]) + bootstrap
+    R = th.zeros_like(rewards) + bootstrap
     discounted = th.zeros_like(rewards)
     length = discounted.size(0)
     for t in reversed(range(length)):


### PR DESCRIPTION
Sorry if I am opening so many PRs :sweat_smile: 
There was i bug in the `td.discount` function when using it in a vectorized environment. I fixed it and wrote a test that compute the discounted rewards of a replay coming from a non vectorized environment and the discounted rewards of a replay coming from a vectorized environment and check if they are the same.
This PR is needed to make #26 work because my A2C implementation uses a vectorized environment