### PR TITLE
Fix action and state sizes for num vec envs = 1

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+
+### Description
+
+Fixes #[ISSUE NUMBER]
+
+Replace this line by a one sentence summary of your PR.
+
+If necessary, use the following space to provide context or more details.
+
+### Contribution Checklist
+
+If your contribution modifies code in the core library (not docs, tests, or examples), please fill the following checklist.
+
+- [x] My contribution modifies code in the main library.
+- [ ] My modifications are tested.
+- [ ] My modifications are documented.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,5 +18,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* env.action_size and env.state_size when the number of vectorized environments is 1. (thanks @galatolofederico)
 * Actor-critic integration test being to finicky.
 * `cherry.onehot` support for numpy's float and integer types. (thanks @ngoby)

--- a/cherry/distributions.py
+++ b/cherry/distributions.py
@@ -107,7 +107,8 @@ class ActionDistribution(nn.Module):
         self.is_discrete = ch.envs.is_discrete(env.action_space)
         if not self.is_discrete:
             if logstd is None:
-                action_size = ch.envs.get_space_dimension(env.action_space)
+                action_size = ch.envs.get_space_dimension(env.action_space,
+                                                          vectorized_dims=False)
                 logstd = nn.Parameter(th.zeros(action_size))
             if isinstance(logstd, (float, int)):
                 logstd = nn.Parameter(th.Tensor([logstd]))

--- a/cherry/envs/base.py
+++ b/cherry/envs/base.py
@@ -33,13 +33,21 @@ class Wrapper(gym.Wrapper):
 
     @property
     def state_size(self):
-        vectorized = not is_vectorized(self)
-        return get_space_dimension(self.observation_space, vectorized=vectorized)
+        """
+        The (flattened) size of a single state.
+        """
+        # Since we want the underlying dimension, vec_dim=False
+        return get_space_dimension(self.observation_space,
+                                   vectorized_dims=False)
 
     @property
     def action_size(self):
-        vectorized = not is_vectorized(self)
-        return get_space_dimension(self.action_space, vectorized=vectorized)
+        """
+        The number of dimensions of a single action.
+        """
+        # Since we want the underlying dimension, vec_dim=False
+        return get_space_dimension(self.action_space,
+                                   vectorized_dims=False)
 
     def __getattr__(self, attr):
         if attr in self.__dict__.keys():

--- a/cherry/envs/torch_wrapper.py
+++ b/cherry/envs/torch_wrapper.py
@@ -29,7 +29,9 @@ class Torch(Wrapper):
             state = {k: self._convert_state(state[k]) for k in state}
         if isinstance(state, np.ndarray):
             state = ch.totensor(state)
-        if self.is_vectorized and isinstance(state, th.Tensor):
+        # we need to check for num_envs because self.is_vectorized returns
+        # False when the num_envs=1, but the state still needs squeezing.
+        if hasattr(self, 'num_envs') and isinstance(state, th.Tensor):
             state = state.squeeze(0)
         return state
 

--- a/cherry/envs/utils.py
+++ b/cherry/envs/utils.py
@@ -50,14 +50,14 @@ def is_discrete(space, vectorized=False):
         return discrete
 
 
-def get_space_dimension(space, vectorized=False):
+def get_space_dimension(space, vectorized_dims=False):
     """
     Returns the number of elements of a space sample, when unrolled.
 
     **Arguments**
 
     * **space** - The space.
-    * **vectorized** - Whether to return the full dimension for vectorized
+    * **vectorized_dims** - Whether to return the full dimension for vectorized
         environments (True) or just the dimension for the underlying
         environment (False).
     """
@@ -66,17 +66,17 @@ def get_space_dimension(space, vectorized=False):
     if isinstance(space, Discrete):
         return space.n
     if isinstance(space, Box):
-        if len(space.shape) > 1 and not vectorized:
+        if len(space.shape) > 1 and not vectorized_dims:
             return reduce(operator.mul, space.shape[1:], 1)
         return reduce(operator.mul, space.shape, 1)
     if isinstance(space, Dict):
         dimensions = {
-            k[0]: get_space_dimension(k[1], vectorized) for k in space.spaces.items()
+            k[0]: get_space_dimension(k[1], vectorized_dims) for k in space.spaces.items()
         }
         return OrderedDict(dimensions)
     if isinstance(space, Tuple):
-        if not vectorized:
-            return get_space_dimension(space[0], vectorized)
+        if not vectorized_dims:
+            return get_space_dimension(space[0], vectorized_dims)
         dimensions = tuple(
             get_space_dimension(s) for s in space
         )

--- a/tests/unit/base_wrapper_tests.py
+++ b/tests/unit/base_wrapper_tests.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+
+import cherry
+import gym
+import operator
+import unittest
+
+from functools import reduce
+from gym.spaces import Box, Discrete
+
+
+def ref_space_dims(space):
+    if isinstance(space, Discrete):
+        return space.n
+    if isinstance(space, Box):
+        return reduce(operator.mul, space.shape, 1)
+
+
+class TestBaseWrapper(unittest.TestCase):
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_sizes(self):
+        for env_name in ['CartPole-v0', 'Pendulum-v0']:
+            ref_env = gym.make(env_name)
+            cherry_env = cherry.envs.Torch(ref_env)
+
+            # Test base implementation
+            ref_action_size = cherry_env.action_size
+            ref_state_size = cherry_env.state_size
+            self.assertTrue(isinstance(ref_action_size, int))
+            self.assertTrue(isinstance(ref_state_size, int))
+            self.assertEqual(ref_action_size, ref_space_dims(ref_env.action_space))
+            self.assertEqual(ref_state_size, ref_space_dims(ref_env.observation_space))
+
+            ref_state_shape = (1,) + ref_env.reset().shape
+            cherry_state_shape = cherry_env.reset().shape
+            self.assertEqual(ref_state_shape, cherry_state_shape)
+
+            # Test vectorized environments
+            for num_envs in range(1, 4):
+                vec_env = gym.vector.make(env_name, num_envs=num_envs)
+                cherry_env = cherry.envs.Torch(vec_env)
+                self.assertTrue(isinstance(cherry_env.state_size, int))
+                self.assertTrue(isinstance(cherry_env.action_size, int))
+                self.assertEqual(cherry_env.state_size, ref_state_size)
+                self.assertEqual(cherry_env.action_size, ref_action_size)
+
+                ref_state_shape = (num_envs,) + ref_env.reset().shape
+                cherry_state_shape = cherry_env.reset().shape
+                self.assertEqual(ref_state_shape, cherry_state_shape)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
# Description

Fixes #25 

When using vectorized environments (`gym.vector`) that `state_size` and `action_size` had inconsistent behaviors.

This PR fixes the issue, adds tests, and some minor documentation.

Thanks to @galatolofederico for pointing out the issue and investigating the root cause.

### Contribution Checklist

If your contribution modifies code in the core library (not docs, tests, or examples), please fill the following checklist.

- [x] My contribution modifies code in the main library.
- [x] My modifications are tested.
- [x] My modifications are documented.
