### PR TITLE
Fix PyTorch 1.5.0 incompatibility in replay buffer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,6 @@ examples/bsuite/figs/**
 
 # ignore .idea 
 *.idea
+
+# ignore .vscode
+.vscode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* Support for more recent versions of PyTorch and new `_parse_to` behavior (thanks @ManifoldFR)
+
 ## v0.1.3
 
 ### Added

--- a/cherry/experience_replay.py
+++ b/cherry/experience_replay.py
@@ -110,7 +110,7 @@ class Transition(object):
         ~~~
 
         """
-        device, dtype, non_blocking = th._C._nn._parse_to(*args, **kwargs)
+        device, dtype, non_blocking, *_ = th._C._nn._parse_to(*args, **kwargs)
         return self._apply(lambda t: t.to(device, dtype if t.is_floating_point() else None, non_blocking), device)
 
     def half(self):
@@ -410,7 +410,7 @@ class ExperienceReplay(list):
         ~~~
 
         """
-        device, dtype, non_blocking = th._C._nn._parse_to(*args, **kwargs)
+        device, dtype, non_blocking, *_ = th._C._nn._parse_to(*args, **kwargs)
         storage = [sars.to(*args, **kwargs) for sars in self._storage]
         return ExperienceReplay(storage, device=device)
 


### PR DESCRIPTION
### Description

Fix support for PyTorch 1.5.0

[This commit](https://github.com/pytorch/pytorch/commit/66f2bba8527d941c7d73d3cae9e9576c601587a6) changed the return tuple size of the function `torch._C._nn._parse_to` to 4 elements instead of 3, which breaks the unpacking in [line 113 of experiencereplay.py](https://github.com/learnables/cherry/blob/c69d1a833b423b8eeaf94baa0b5237e05af7c38a/cherry/experience_replay.py#L113). I only changed the unpacking logic to `device, dtype, non_blocking, *_ = ...` to ensure the trailing part of the unpack can be any length.
I also added `.vscode` to the gitignore

### Contribution Checklist

If your contribution modifies code in the core library (not docs, tests, or examples), please fill the following checklist.

- [x] My contribution modifies code in the main library.
- [x] My modifications are tested (on PyTorch 1.5.0 and on PyTorch 1.3.1 to check backward compatibility)
- [x] My modifications are documented.
